### PR TITLE
refact_render チラつき改善

### DIFF
--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1,3 +1,15 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   game.h                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/17 15:12:53 by nando             #+#    #+#             */
+/*   Updated: 2025/10/17 15:15:21 by nando            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #ifndef GAME_H
 # define GAME_H
 
@@ -5,13 +17,9 @@
 # include <math.h>
 # include <stdlib.h>
 
-// ウィンドウとキーの定数
+// window size
 # define WIN_W 960
 # define WIN_H 720
-
-# define CEILING_COLOR 0x87CEEB
-# define FLOOR_COLOR 0x8B4513
-# define WALL_COLOR 0x808080
 
 # define VIEWING_ANGLE 0.66
 # define DIR_FORWARD 1
@@ -29,7 +37,6 @@
 # define MOVE_SPEED 0.1
 # define ROTATE_SPEED 0.05
 
-// 画像データ構造体
 typedef struct s_image_data
 {
 	void			*canvas;
@@ -41,7 +48,6 @@ typedef struct s_image_data
 	int				width;
 }					t_image_data;
 
-// プレイヤー構造体
 typedef struct s_player
 {
 	double			player_dir;
@@ -55,7 +61,7 @@ typedef struct s_player
 	double			plane_y;
 }					t_player;
 
-// gameディレクトリで使用するマップデータファイル
+// world data used game_dir
 typedef struct s_world
 {
 	char			*no_path;
@@ -67,7 +73,7 @@ typedef struct s_world
 	char			**map;
 }					t_world_data;
 
-// レイキャスティング用構造体
+// raycasting
 typedef struct s_ray
 {
 	double			camera_x;
@@ -109,7 +115,6 @@ typedef struct s_render
 	int				side;
 }					t_render;
 
-// DDA用構造体
 typedef struct s_dda
 {
 	int				map_x;
@@ -128,12 +133,11 @@ typedef struct s_game
 {
 	void			*mlx;
 	void			*win;
-	t_world_data world; // parse層から受け取る
-	t_player player;    // game層で更新
-	t_render render;    // render層で使用
+	t_world_data world; // received from parse
+	t_player player;	// update game_dir
+	t_render render;
 }					t_game;
 
-// 関数プロトタイプ
 void				calculate_ray(t_ray *r, t_player *p, int x);
 void				init_game(t_game *g);
 void				dda(t_game *g);

--- a/src/game/game_engine.c
+++ b/src/game/game_engine.c
@@ -1,3 +1,14 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   game_engine.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/17 15:12:36 by nando             #+#    #+#             */
+/*   Updated: 2025/10/17 15:17:22 by nando            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
 
 #include "game.h"
 
@@ -12,17 +23,14 @@ static int	render_frame(t_game *g)
 
 static void	run_game(t_game *g)
 {
-	mlx_hook(g->win, 2, 1L << 0, handle_key_press, g); // キー入力時
-	mlx_loop_hook(g->mlx, render_frame, g);            // 毎フレーム呼ばれる
-	render_frame(g);                                   // 初期描画
+	mlx_hook(g->win, 2, 1L << 0, handle_key_press, g);
+	mlx_loop_hook(g->mlx, render_frame, g);
 }
 
-int	execute_game(t_game *game)
+int	execute_game(t_game *g)
 {
-	init_game(game);
-	run_game(game);
-	mlx_put_image_to_window(game->mlx, game->win, game->render.img.canvas, 0,
-		0);
-	mlx_loop(game->mlx);
+	init_game(g);
+	run_game(g);
+	mlx_loop(g->mlx);
 	return (0);
 }

--- a/src/game/key_operation/handle_key.c
+++ b/src/game/key_operation/handle_key.c
@@ -1,3 +1,14 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   handle_key.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nando <nando@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/17 15:12:29 by nando             #+#    #+#             */
+/*   Updated: 2025/10/17 15:12:32 by nando            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
 
 #include "game.h"
 #include "mlx.h"
@@ -39,6 +50,7 @@ void	rotate(t_player *p, int keycode)
 
 int	handle_key_press(int keycode, t_game *g, t_world_data *data)
 {
+	(void)data;
 	if (keycode == ESC_KEY)
 		return (close_window(g));
 	else if (keycode == KEY_W || keycode == KEY_S || keycode == KEY_A
@@ -46,9 +58,5 @@ int	handle_key_press(int keycode, t_game *g, t_world_data *data)
 		move(g, keycode);
 	else if (keycode == KEY_LEFT || keycode == KEY_RIGHT)
 		rotate(&g->player, keycode);
-	rendering_ceiling_and_floor(g, data);
-	rendering_walls(g);
-	b_render(g);
-	mlx_put_image_to_window(g->mlx, g->win, g->render.img.canvas, 0, 0);
 	return (0);
 }


### PR DESCRIPTION
”ちらつき”を改善しました

キー入力ごとに複数回レンダリングしていたため、”ちらつき”が出ていた模様。
・handle_key関数ではプレイヤーの座標や視野の変化のみ実行
・render_frame関数にレンダリングを全て行わせる

※ノームはまだです。